### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ check:
 	./scripts/check.sh $(DEBUGGER)
 
 install:
-	install -d -m 755 $(PREFIX)/include/cware
-	install -m 755 src/chash.h $(PREFIX)/include/cware
+	install -d -m 755 $(PREFIX)/include/cware/chash
+	install -m 755 src/chash.h $(PREFIX)/include/cware/chash
 	install -d -m 755 $(PREFIX)/share/man/mancware
 	for manual in $(MANNAMES); do \
 		install -m 755 doc/$$manual $(PREFIX)/share/man/mancware; \
@@ -31,12 +31,12 @@ install:
 
 
 uninstall:
-	rm -f $(PREFIX)/include/cware/chash.h
+	rm -f $(PREFIX)/include/cware/chash/chash.h
 	for manual in $(MANNAMES); do  \
 		rm -f $(PREFIX)/share/man/mancware/$$manual; \
 	done
 	rmdir $(PREFIX)/share/man/mancware
-	rmdir $(PREFIX)/include/cware
+	rmdir $(PREFIX)/include/cware/chash
 
 .c.out:
 	$(CC) $< $(OBJS) $(CFLAGS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 
 CC=cc
 PREFIX=/usr/local
-CFLAGS=-ansi -Wall -Wextra -Wshadow -Wdouble-promotion -fpic -Wno-unused-variable -Wno-unused-function -Wno-sign-compare
+# CFLAGS=-ansi -Wall -Wextra -Wshadow -Wdouble-promotion -fpic -Wno-unused-variable -Wno-unused-function -Wno-sign-compare
 TESTS=tests/free.out tests/assign.out tests/struct_values.out tests/stack_init.out tests/stack_lookup.out tests/stack_contains.out tests/stack_assign.out tests/stack_free.out tests/lookup.out tests/delete.out tests/contains.out tests/stack_delete.out tests/init.out 
-DOCS=./doc/chash.cware ./doc/chash_init_stack.cware ./doc/chash_init.cware ./doc/chash_assign.cware 
+DOCS=doc/chash.cware doc/chash_init_stack.cware doc/chash_init.cware doc/chash_assign.cware 
 MANNAMES=chash.cware chash_init_stack.cware chash_init.cware chash_assign.cware 
 DEBUGGER=
 
@@ -22,12 +22,21 @@ check:
 	./scripts/check.sh $(DEBUGGER)
 
 install:
-	cp $(DOCS) $(PREFIX)/share/man/mancware
+	install -d -m 755 $(PREFIX)/include/cware
+	install -m 755 src/chash.h $(PREFIX)/include/cware
+	install -d -m 755 $(PREFIX)/share/man/mancware
+	for manual in $(MANNAMES); do \
+		install -m 755 doc/$$manual $(PREFIX)/share/man/mancware; \
+	done
+
 
 uninstall:
+	rm -f $(PREFIX)/include/cware/chash.h
 	for manual in $(MANNAMES); do  \
 		rm -f $(PREFIX)/share/man/mancware/$$manual; \
 	done
+	rmdir $(PREFIX)/share/man/mancware
+	rmdir $(PREFIX)/include/cware
 
 .c.out:
 	$(CC) $< $(OBJS) $(CFLAGS) -o $@


### PR DESCRIPTION
Yes, this is generated by a macro processor, but I went ahead and modified the Makefile to use more standard installation techniques, as well as to deposit the headers into $PREFIX. 

I commented out the GNU-specific CFLAGS, as it was erroring out the SVR4 C compiler.